### PR TITLE
M4: MTC-3563 AWS patch 

### DIFF
--- a/app/bundles/EmailBundle/Model/TransportCallback.php
+++ b/app/bundles/EmailBundle/Model/TransportCallback.php
@@ -50,8 +50,14 @@ class TransportCallback
             $this->updateStatDetails($stat, $comments, $dncReason);
 
             $email   = $stat->getEmail();
-            $channel = ($email) ? ['email' => $email->getId()] : 'email';
             foreach ($contacts as $contact) {
+                if (str_starts_with($comments, 'SOFT: AWS')) {
+                    $channel = 'AWS';
+                } elseif (str_starts_with($comments, 'SOFT')) {
+                    $channel = 'mailjet';
+                } else {
+                    $channel = ($email) ? ['email' => $email->getId()] : 'email';
+                }
                 $this->dncModel->addDncForContact($contact->getId(), $channel, $dncReason, $comments);
             }
         }
@@ -69,7 +75,13 @@ class TransportCallback
 
         if ($contacts = $result->getContacts()) {
             foreach ($contacts as $contact) {
-                $channel = ($channelId) ? ['email' => $channelId] : 'email';
+                if (str_starts_with($comments, 'SOFT: AWS')) {
+                    $channel = 'AWS';
+                } elseif (str_starts_with($comments, 'SOFT')) {
+                    $channel = 'mailjet';
+                } else {
+                    $channel = ($channelId) ? ['email' => $channelId] : 'email';
+                }
                 $this->dncModel->addDncForContact($contact->getId(), $channel, $dncReason, $comments);
             }
         }
@@ -83,7 +95,13 @@ class TransportCallback
      */
     public function addFailureByContactId($id, $comments, $dncReason = DNC::BOUNCED, $channelId = null)
     {
-        $channel = ($channelId) ? ['email' => $channelId] : 'email';
+        if (str_starts_with($comments, 'SOFT: AWS')) {
+            $channel = 'AWS';
+        } elseif (str_starts_with($comments, 'SOFT')) {
+            $channel = 'mailjet';
+        } else {
+            $channel = ($channelId) ? ['email' => $channelId] : 'email';
+        }
         $this->dncModel->addDncForContact($id, $channel, $dncReason, $comments);
     }
 


### PR DESCRIPTION
## Description:
The current behaviour of mautic (explicit by the `AmazonCallback.php` file) is, that just contacts with the callback status "hardbounced" (in amazon called `Permanent`) are set to DNC and in consequence getting an entry in `lead_donotcontact`.

### Offered solution with this patch:
- Also contacts with the callback status `softbounced` (in amazon called `Transient`) will get an entry in the table `lead_donotcontact`, but the channel for these amazon softbounced emails will be set to `AWS` so that the contacts of these emails do not get the contact status `DNC`
- In the comment field of the table `lead_donotconact` additional are persisted following prefixes
- `** SOFT: AWS:`  for the callback status softbounced (in amazon called `Transient`)
- `** HARD: AWS:`  for the callback status hardbounced (in amazon called `Permanent`)
- `** OTHER: AWS:`  if there is another bounced callback status
- In the `comment` field of the table `lead_donotcontact` will also be persisted the value of bounceSubType of the amazon callback
- Furthermore the value of `diagnosticCode` of the amazon callback status is persisted in the comment field of the table `lead_donotcontact` (just like before)