### PR TITLE
M4: Mailjet Patch 4.4.10+

### DIFF
--- a/app/bundles/EmailBundle/Model/TransportCallback.php
+++ b/app/bundles/EmailBundle/Model/TransportCallback.php
@@ -50,8 +50,12 @@ class TransportCallback
             $this->updateStatDetails($stat, $comments, $dncReason);
 
             $email   = $stat->getEmail();
-            $channel = ($email) ? ['email' => $email->getId()] : 'email';
             foreach ($contacts as $contact) {
+                if (str_starts_with($comments, 'SOFT')) {
+                    $channel = 'mailjet';
+                } else {
+                    $channel = ($email) ? ['email' => $email->getId()] : 'email';
+                }
                 $this->dncModel->addDncForContact($contact->getId(), $channel, $dncReason, $comments);
             }
         }
@@ -69,8 +73,11 @@ class TransportCallback
 
         if ($contacts = $result->getContacts()) {
             foreach ($contacts as $contact) {
-                $channel = ($channelId) ? ['email' => $channelId] : 'email';
-                $this->dncModel->addDncForContact($contact->getId(), $channel, $dncReason, $comments);
+                if (str_starts_with($comments, 'SOFT')) {
+                    $channel = 'mailjet';
+                } else {
+                    $channel = ($channelId) ? ['email' => $channelId] : 'email';
+                }                $this->dncModel->addDncForContact($contact->getId(), $channel, $dncReason, $comments);
             }
         }
     }
@@ -83,8 +90,11 @@ class TransportCallback
      */
     public function addFailureByContactId($id, $comments, $dncReason = DNC::BOUNCED, $channelId = null)
     {
-        $channel = ($channelId) ? ['email' => $channelId] : 'email';
-        $this->dncModel->addDncForContact($id, $channel, $dncReason, $comments);
+        if (str_starts_with($comments, 'SOFT')) {
+            $channel = 'mailjet';
+        } else {
+            $channel = ($channelId) ? ['email' => $channelId] : 'email';
+        }        $this->dncModel->addDncForContact($id, $channel, $dncReason, $comments);
     }
 
     /**


### PR DESCRIPTION
Patch does not fail with -> mautic 4.4.10

### Description:
In Mautic 4.4.10 release (https://github.com/mautic/mautic/releases/tag/4.4.10) the fixes for "mailjet puts only : in lead_donotcontact.comment" are now already implemented in `app/bundles/EmailBundle/Swiftmailer/Transport/MailjetTransport.php`

So for the mailjet patch for mautic 4.4.10 is only necessary the additional setting of the channel in table lead_donotcontact to mailjet if the "mailjet status" for the email is "softbounced" in mailjet.
And this is done with this PR patched/mailjet-mautic4.4.10.