### PR TITLE
M4: Allow longer HTML Field Name in Forms

### DIFF
--- a/app/bundles/FormBundle/Model/FieldModel.php
+++ b/app/bundles/FormBundle/Model/FieldModel.php
@@ -143,7 +143,7 @@ class FieldModel extends CommonFormModel
      */
     public function generateAlias($label, &$aliases)
     {
-        $alias = $this->cleanAlias($label, 'f_', 25);
+        $alias = $this->cleanAlias($label, 'f_', 64);
 
         //make sure alias is not already taken
         $testAlias = $alias;


### PR DESCRIPTION
- Allow longer HTML Fields so they can match the field names in C4C