### PR TITLE
MTC-10741 Add Batch Contact-to-Company Assignment API (M5)

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -242,6 +242,11 @@ return [
                 'path'            => '/companies',
                 'controller'      => Mautic\LeadBundle\Controller\Api\CompanyApiController::class,
             ],
+            'mautic_api_companybatchaddcontacts' => [
+                'path'       => '/companies/batch/addcontacts',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\CompanyApiController::batchAddContactsAction',
+                'method'     => 'POST',
+            ],
             'mautic_api_companyaddcontact' => [
                 'path'       => '/companies/{companyId}/contact/{contactId}/add',
                 'controller' => 'Mautic\LeadBundle\Controller\Api\CompanyApiController::addContactAction',

--- a/app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
@@ -15,9 +15,11 @@ use Mautic\LeadBundle\Controller\LeadAccessTrait;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Helper\IdentifyCompanyHelper;
+use Mautic\LeadBundle\Model\BatchCompanyContactAssignmentModel;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
@@ -35,8 +37,21 @@ class CompanyApiController extends CommonApiController
      */
     protected $model;
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, MauticFactory $factory)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        MauticFactory $factory,
+        private BatchCompanyContactAssignmentModel $batchCompanyContactAssignmentModel,
+    ) {
         $companyModel = $modelFactory->getModel('lead.company');
         \assert($companyModel instanceof CompanyModel);
 
@@ -97,6 +112,37 @@ class CompanyApiController extends CommonApiController
         $this->model->addLeadToCompany($company, $contact);
 
         return $this->handleView($view);
+    }
+
+    /**
+     * Assigns multiple contacts to multiple companies in one request.
+     */
+    public function batchAddContactsAction(Request $request): Response
+    {
+        if (!$this->security->isGranted('lead:leads:editown') && !$this->security->isGranted('lead:leads:editother')) {
+            return $this->accessDenied();
+        }
+
+        $assignments = $request->request->all('assignments');
+
+        if (!is_array($assignments) || [] === $assignments) {
+            return $this->returnError('assignments is required and must be a non-empty array', Response::HTTP_BAD_REQUEST);
+        }
+
+        foreach ($assignments as $entry) {
+            if (!is_array($entry)) {
+                return $this->returnError('assignments is required and must be a non-empty array', Response::HTTP_BAD_REQUEST);
+            }
+        }
+
+        $valid = $this->validateBatchPayload($assignments);
+        if ($valid instanceof Response) {
+            return $valid;
+        }
+
+        $payload = $this->batchCompanyContactAssignmentModel->process($assignments);
+
+        return $this->handleView($this->view($payload, Response::HTTP_OK));
     }
 
     /**

--- a/app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
@@ -52,7 +52,7 @@ class CompanyApiController extends CommonApiController
         MauticFactory $factory,
         private BatchCompanyContactAssignmentModel $batchCompanyContactAssignmentModel,
     ) {
-        $companyModel = $modelFactory->getModel('lead.company');
+        $companyModel = $modelFactory->getModel(CompanyModel::class);
         \assert($companyModel instanceof CompanyModel);
 
         $this->model              = $companyModel;
@@ -127,12 +127,12 @@ class CompanyApiController extends CommonApiController
         $assignments = $parameters['assignments'] ?? null;
 
         if (!is_array($assignments) || [] === $assignments) {
-            return $this->returnError('assignments is required and must be a non-empty array', Response::HTTP_BAD_REQUEST);
+            return $this->returnError('"assignments" parameter is required and must be a non-empty array', Response::HTTP_BAD_REQUEST);
         }
 
         foreach ($assignments as $entry) {
             if (!is_array($entry)) {
-                return $this->returnError('assignments is required and must be a non-empty array', Response::HTTP_BAD_REQUEST);
+                return $this->returnError('Assignments entries must be a non-empty array', Response::HTTP_BAD_REQUEST);
             }
         }
 

--- a/app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
@@ -123,7 +123,8 @@ class CompanyApiController extends CommonApiController
             return $this->accessDenied();
         }
 
-        $assignments = $request->request->all('assignments');
+        $parameters  = $request->request->all();
+        $assignments = $parameters['assignments'] ?? null;
 
         if (!is_array($assignments) || [] === $assignments) {
             return $this->returnError('assignments is required and must be a non-empty array', Response::HTTP_BAD_REQUEST);

--- a/app/bundles/LeadBundle/Model/BatchCompanyContactAssignmentModel.php
+++ b/app/bundles/LeadBundle/Model/BatchCompanyContactAssignmentModel.php
@@ -25,7 +25,7 @@ class BatchCompanyContactAssignmentModel
     }
 
     /**
-     * @param array<int, array<string, mixed>> $assignments
+     * @param non-empty-array<int, array<string, mixed>> $assignments
      *
      * @return array{results: list<array{contactId: int, companyId: int, status: int, message: string}>, summary: array{total: int, succeeded: int, failed: int}}
      */
@@ -98,6 +98,7 @@ class BatchCompanyContactAssignmentModel
 
         foreach ($companyIdsByContact as $contactId => $companyIdsForContact) {
             $contact = $contactsById[$contactId];
+            sort($companyIdsForContact);
 
             try {
                 $this->companyModel->addLeadToCompany($companyIdsForContact, $contact);

--- a/app/bundles/LeadBundle/Model/BatchCompanyContactAssignmentModel.php
+++ b/app/bundles/LeadBundle/Model/BatchCompanyContactAssignmentModel.php
@@ -38,11 +38,11 @@ class BatchCompanyContactAssignmentModel
 
         $contactIds    = [];
         $companyIds    = [];
+        /** @var array<string, array{contactId: int, companyId: int}> $pairsToAssign */
         $pairsToAssign = [];
 
-        foreach ($dedupedForProcessing as $entry) {
+        foreach ($dedupedForProcessing as $pairKey => $entry) {
             [$contactId, $companyId] = self::parsePair($entry);
-            $pairKey                 = self::pairKey($contactId, $companyId);
 
             if ($contactId <= 0) {
                 $outcomes[$pairKey] = self::resultEntry($contactId, $companyId, Response::HTTP_NOT_FOUND, self::MESSAGE_CONTACT_NOT_FOUND);
@@ -54,9 +54,9 @@ class BatchCompanyContactAssignmentModel
                 continue;
             }
 
-            $contactIds[$contactId] = $contactId;
-            $companyIds[$companyId] = $companyId;
-            $pairsToAssign[]        = ['contactId' => $contactId, 'companyId' => $companyId];
+            $contactIds[$contactId]  = $contactId;
+            $companyIds[$companyId]  = $companyId;
+            $pairsToAssign[$pairKey] = ['contactId' => $contactId, 'companyId' => $companyId];
         }
 
         $contactsById  = $this->loadContactsById(array_values($contactIds));
@@ -65,14 +65,13 @@ class BatchCompanyContactAssignmentModel
         /** @var array<int, list<int>> $companyIdsByContact */
         $companyIdsByContact = [];
 
-        foreach ($pairsToAssign as $pair) {
-            $contactId = $pair['contactId'];
-            $companyId = $pair['companyId'];
-            $pairKey   = self::pairKey($contactId, $companyId);
-
+        foreach ($pairsToAssign as $pairKey => $pair) {
             if (isset($outcomes[$pairKey])) {
                 continue;
             }
+
+            $contactId = $pair['contactId'];
+            $companyId = $pair['companyId'];
 
             $contact = $contactsById[$contactId] ?? null;
             if (!$contact instanceof Lead) {
@@ -97,11 +96,11 @@ class BatchCompanyContactAssignmentModel
             $companyIdsByContact[$contactId][] = $companyId;
         }
 
-        foreach ($companyIdsByContact as $contactId => $idsForContact) {
+        foreach ($companyIdsByContact as $contactId => $companyIdsForContact) {
             $contact = $contactsById[$contactId];
 
             try {
-                $this->companyModel->addLeadToCompany($idsForContact, $contact);
+                $this->companyModel->addLeadToCompany($companyIdsForContact, $contact);
                 $status  = Response::HTTP_OK;
                 $message = self::MESSAGE_ADDED;
             } catch (\Throwable) {
@@ -109,7 +108,7 @@ class BatchCompanyContactAssignmentModel
                 $message = self::MESSAGE_UNEXPECTED;
             }
 
-            foreach ($idsForContact as $companyId) {
+            foreach ($companyIdsForContact as $companyId) {
                 $outcomes[self::pairKey($contactId, $companyId)] = self::resultEntry($contactId, $companyId, $status, $message);
             }
         }
@@ -150,12 +149,12 @@ class BatchCompanyContactAssignmentModel
     /**
      * @param array<int, array<string, mixed>> $assignments
      *
-     * @return list<array{contactId: int, companyId: int}>
+     * @return array<string, array{contactId: int, companyId: int}>
      */
-    public static function dedupeAssignments(array $assignments): array
+    private static function dedupeAssignments(array $assignments): array
     {
+        /** @var array<string, array{contactId: int, companyId: int}> $deduped */
         $deduped = [];
-        $seen    = [];
 
         foreach ($assignments as $entry) {
             if (!is_array($entry)) {
@@ -165,12 +164,11 @@ class BatchCompanyContactAssignmentModel
             [$contactId, $companyId] = self::parsePair($entry);
             $key                     = self::pairKey($contactId, $companyId);
 
-            if (isset($seen[$key])) {
+            if (isset($deduped[$key])) {
                 continue;
             }
 
-            $seen[$key] = true;
-            $deduped[]  = ['contactId' => $contactId, 'companyId' => $companyId];
+            $deduped[$key] = ['contactId' => $contactId, 'companyId' => $companyId];
         }
 
         return $deduped;
@@ -181,7 +179,7 @@ class BatchCompanyContactAssignmentModel
      *
      * @return array{0: int, 1: int}
      */
-    public static function parsePair(array $entry): array
+    private static function parsePair(array $entry): array
     {
         return [
             (int) ($entry['contactId'] ?? 0),
@@ -205,8 +203,11 @@ class BatchCompanyContactAssignmentModel
             return [];
         }
 
-        $contacts = $this->leadModel->getRepository()->findBy(['id' => $ids]);
-        $indexed  = [];
+        $contacts = $this->leadModel->getEntities([
+            'ids'            => $ids,
+            'iterable_mode'  => true,
+        ]);
+        $indexed = [];
 
         foreach ($contacts as $contact) {
             \assert($contact instanceof Lead);
@@ -227,8 +228,11 @@ class BatchCompanyContactAssignmentModel
             return [];
         }
 
-        $companies = $this->companyModel->getRepository()->findBy(['id' => $ids]);
-        $indexed   = [];
+        $companies = $this->companyModel->getEntities([
+            'ids'            => $ids,
+            'iterable_mode'  => true,
+        ]);
+        $indexed = [];
 
         foreach ($companies as $company) {
             \assert($company instanceof Company);

--- a/app/bundles/LeadBundle/Model/BatchCompanyContactAssignmentModel.php
+++ b/app/bundles/LeadBundle/Model/BatchCompanyContactAssignmentModel.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Model;
+
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\Lead;
+use Symfony\Component\HttpFoundation\Response;
+
+class BatchCompanyContactAssignmentModel
+{
+    private const MESSAGE_ADDED             = 'Contact added to company';
+    private const MESSAGE_CONTACT_NOT_FOUND = 'Contact not found';
+    private const MESSAGE_COMPANY_NOT_FOUND = 'Company not found';
+    private const MESSAGE_ACCESS_DENIED     = 'Access denied';
+    private const MESSAGE_UNEXPECTED        = 'An unexpected error occurred';
+
+    public function __construct(
+        private CompanyModel $companyModel,
+        private LeadModel $leadModel,
+        private CorePermissions $security,
+    ) {
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assignments
+     *
+     * @return array{results: list<array{contactId: int, companyId: int, status: int, message: string}>, summary: array{total: int, succeeded: int, failed: int}}
+     */
+    public function process(array $assignments): array
+    {
+        $dedupedForProcessing = self::dedupeAssignments($assignments);
+
+        /** @var array<string, array{contactId: int, companyId: int, status: int, message: string}> $outcomes */
+        $outcomes = [];
+
+        $contactIds    = [];
+        $companyIds    = [];
+        $pairsToAssign = [];
+
+        foreach ($dedupedForProcessing as $entry) {
+            [$contactId, $companyId] = self::parsePair($entry);
+            $pairKey                 = self::pairKey($contactId, $companyId);
+
+            if ($contactId <= 0) {
+                $outcomes[$pairKey] = self::resultEntry($contactId, $companyId, Response::HTTP_NOT_FOUND, self::MESSAGE_CONTACT_NOT_FOUND);
+                continue;
+            }
+
+            if ($companyId <= 0) {
+                $outcomes[$pairKey] = self::resultEntry($contactId, $companyId, Response::HTTP_NOT_FOUND, self::MESSAGE_COMPANY_NOT_FOUND);
+                continue;
+            }
+
+            $contactIds[$contactId] = $contactId;
+            $companyIds[$companyId] = $companyId;
+            $pairsToAssign[]        = ['contactId' => $contactId, 'companyId' => $companyId];
+        }
+
+        $contactsById  = $this->loadContactsById(array_values($contactIds));
+        $companiesById = $this->loadCompaniesById(array_values($companyIds));
+
+        /** @var array<int, list<int>> $companyIdsByContact */
+        $companyIdsByContact = [];
+
+        foreach ($pairsToAssign as $pair) {
+            $contactId = $pair['contactId'];
+            $companyId = $pair['companyId'];
+            $pairKey   = self::pairKey($contactId, $companyId);
+
+            if (isset($outcomes[$pairKey])) {
+                continue;
+            }
+
+            $contact = $contactsById[$contactId] ?? null;
+            if (!$contact instanceof Lead) {
+                $outcomes[$pairKey] = self::resultEntry($contactId, $companyId, Response::HTTP_NOT_FOUND, self::MESSAGE_CONTACT_NOT_FOUND);
+                continue;
+            }
+
+            if (!isset($companiesById[$companyId])) {
+                $outcomes[$pairKey] = self::resultEntry($contactId, $companyId, Response::HTTP_NOT_FOUND, self::MESSAGE_COMPANY_NOT_FOUND);
+                continue;
+            }
+
+            if (!$this->security->hasEntityAccess(
+                'lead:leads:editown',
+                'lead:leads:editother',
+                $contact->getPermissionUser()
+            )) {
+                $outcomes[$pairKey] = self::resultEntry($contactId, $companyId, Response::HTTP_FORBIDDEN, self::MESSAGE_ACCESS_DENIED);
+                continue;
+            }
+
+            $companyIdsByContact[$contactId][] = $companyId;
+        }
+
+        foreach ($companyIdsByContact as $contactId => $idsForContact) {
+            $contact = $contactsById[$contactId];
+
+            try {
+                $this->companyModel->addLeadToCompany($idsForContact, $contact);
+                $status  = Response::HTTP_OK;
+                $message = self::MESSAGE_ADDED;
+            } catch (\Throwable) {
+                $status  = Response::HTTP_INTERNAL_SERVER_ERROR;
+                $message = self::MESSAGE_UNEXPECTED;
+            }
+
+            foreach ($idsForContact as $companyId) {
+                $outcomes[self::pairKey($contactId, $companyId)] = self::resultEntry($contactId, $companyId, $status, $message);
+            }
+        }
+
+        $results   = [];
+        $succeeded = 0;
+        $failed    = 0;
+
+        foreach ($assignments as $entry) {
+            if (!is_array($entry)) {
+                $results[] = self::resultEntry(0, 0, Response::HTTP_NOT_FOUND, self::MESSAGE_CONTACT_NOT_FOUND);
+                ++$failed;
+                continue;
+            }
+
+            [$contactId, $companyId] = self::parsePair($entry);
+            $pairKey                 = self::pairKey($contactId, $companyId);
+            $result                  = $outcomes[$pairKey] ?? self::resultEntry($contactId, $companyId, Response::HTTP_NOT_FOUND, self::MESSAGE_CONTACT_NOT_FOUND);
+            $results[]               = $result;
+
+            if (Response::HTTP_OK === $result['status']) {
+                ++$succeeded;
+            } else {
+                ++$failed;
+            }
+        }
+
+        return [
+            'results' => $results,
+            'summary' => [
+                'total'     => count($assignments),
+                'succeeded' => $succeeded,
+                'failed'    => $failed,
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $assignments
+     *
+     * @return list<array{contactId: int, companyId: int}>
+     */
+    public static function dedupeAssignments(array $assignments): array
+    {
+        $deduped = [];
+        $seen    = [];
+
+        foreach ($assignments as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+
+            [$contactId, $companyId] = self::parsePair($entry);
+            $key                     = self::pairKey($contactId, $companyId);
+
+            if (isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+            $deduped[]  = ['contactId' => $contactId, 'companyId' => $companyId];
+        }
+
+        return $deduped;
+    }
+
+    /**
+     * @param array<string, mixed> $entry
+     *
+     * @return array{0: int, 1: int}
+     */
+    public static function parsePair(array $entry): array
+    {
+        return [
+            (int) ($entry['contactId'] ?? 0),
+            (int) ($entry['companyId'] ?? 0),
+        ];
+    }
+
+    private static function pairKey(int $contactId, int $companyId): string
+    {
+        return $contactId.':'.$companyId;
+    }
+
+    /**
+     * @param list<int> $ids
+     *
+     * @return array<int, Lead>
+     */
+    private function loadContactsById(array $ids): array
+    {
+        if ([] === $ids) {
+            return [];
+        }
+
+        $contacts = $this->leadModel->getRepository()->findBy(['id' => $ids]);
+        $indexed  = [];
+
+        foreach ($contacts as $contact) {
+            \assert($contact instanceof Lead);
+            $indexed[$contact->getId()] = $contact;
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * @param list<int> $ids
+     *
+     * @return array<int, Company>
+     */
+    private function loadCompaniesById(array $ids): array
+    {
+        if ([] === $ids) {
+            return [];
+        }
+
+        $companies = $this->companyModel->getRepository()->findBy(['id' => $ids]);
+        $indexed   = [];
+
+        foreach ($companies as $company) {
+            \assert($company instanceof Company);
+            $indexed[$company->getId()] = $company;
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * @return array{contactId: int, companyId: int, status: int, message: string}
+     */
+    private static function resultEntry(int $contactId, int $companyId, int $status, string $message): array
+    {
+        return [
+            'contactId' => $contactId,
+            'companyId' => $companyId,
+            'status'    => $status,
+            'message'   => $message,
+        ];
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
@@ -1,14 +1,31 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\CompanyLead;
+use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
+use Mautic\LeadBundle\Model\CompanyModel;
+use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\UserBundle\Entity\Permission;
+use Mautic\UserBundle\Entity\User;
+use Mautic\UserBundle\Model\RoleModel;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
 {
+    private const SALES_USER = 'sales';
+
+    private CompanyModel $companyModel;
+
+    private LeadModel $leadModel;
+
     /**
      * @throws \Doctrine\ORM\Exception\ORMException
      * @throws \Doctrine\ORM\OptimisticLockException
@@ -30,7 +47,12 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->configParams['company_unique_identifiers_operator'] = 'AND';
 
         parent::setUp();
+
+        $this->companyModel = static::getContainer()->get('mautic.lead.model.company');
+        $this->leadModel    = static::getContainer()->get('mautic.lead.model.lead');
     }
+
+    // ─── existing company API tests (from upstream 5.2) ─────────────────────
 
     public function testBatchNewEndpoint(): void
     {
@@ -69,7 +91,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $payload = [
             [
-                'companyname'        => 'BatchUpdate',
+                'companyname' => 'BatchUpdate',
             ],
         ];
 
@@ -111,7 +133,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->markCompanyEmailAsUnique();
 
         $payload = [
-            'companyname'            => 'API',
+            'companyname' => 'API',
         ];
 
         $this->client->request('POST', '/api/companies/new', $payload);
@@ -139,5 +161,238 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
 
         $this->assertNotEquals($companyId, $response['company']['id']);
+    }
+
+    // ─── batch addcontacts tests ─────────────────────────────────────────────
+
+    public function testBatchAddContactsSuccess(): void
+    {
+        $company = $this->createCompany('Batch Co A');
+        $contact = $this->createContact('batch-success@example.com');
+
+        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+            'assignments' => [
+                ['contactId' => $contact->getId(), 'companyId' => $company->getId()],
+            ],
+        ]);
+
+        $response = $this->decodeResponse();
+        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        Assert::assertSame(1, $response['summary']['total']);
+        Assert::assertSame(1, $response['summary']['succeeded']);
+        Assert::assertSame(0, $response['summary']['failed']);
+        Assert::assertSame(Response::HTTP_OK, $response['results'][0]['status']);
+        Assert::assertSame('Contact added to company', $response['results'][0]['message']);
+        Assert::assertTrue($this->isContactInCompany($contact->getId(), $company->getId()));
+    }
+
+    public function testBatchAddContactsPartialFailure(): void
+    {
+        $company = $this->createCompany('Batch Co B');
+        $contact = $this->createContact('batch-partial@example.com');
+
+        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+            'assignments' => [
+                ['contactId' => $contact->getId(), 'companyId' => $company->getId()],
+                ['contactId' => $contact->getId(), 'companyId' => 999999],
+                ['contactId' => 999998, 'companyId' => $company->getId()],
+            ],
+        ]);
+
+        $response = $this->decodeResponse();
+        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        Assert::assertSame(3, $response['summary']['total']);
+        Assert::assertSame(1, $response['summary']['succeeded']);
+        Assert::assertSame(2, $response['summary']['failed']);
+        Assert::assertSame(Response::HTTP_OK, $response['results'][0]['status']);
+        Assert::assertSame(Response::HTTP_NOT_FOUND, $response['results'][1]['status']);
+        Assert::assertSame('Company not found', $response['results'][1]['message']);
+        Assert::assertSame(Response::HTTP_NOT_FOUND, $response['results'][2]['status']);
+        Assert::assertSame('Contact not found', $response['results'][2]['message']);
+    }
+
+    public function testBatchAddContactsEmptyBody(): void
+    {
+        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', []);
+
+        Assert::assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testBatchAddContactsDuplicatePairs(): void
+    {
+        $company = $this->createCompany('Batch Co C');
+        $contact = $this->createContact('batch-dup@example.com');
+
+        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+            'assignments' => [
+                ['contactId' => $contact->getId(), 'companyId' => $company->getId()],
+                ['contactId' => $contact->getId(), 'companyId' => $company->getId()],
+            ],
+        ]);
+
+        $response = $this->decodeResponse();
+        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        // total reflects original input count (including duplicates), succeeded+failed == total
+        Assert::assertSame(2, $response['summary']['total']);
+        Assert::assertSame(2, $response['summary']['succeeded']);
+        Assert::assertSame(0, $response['summary']['failed']);
+        Assert::assertCount(2, $response['results']);
+        Assert::assertSame(Response::HTTP_OK, $response['results'][0]['status']);
+        Assert::assertSame(Response::HTTP_OK, $response['results'][1]['status']);
+        // only one DB row despite two identical input pairs
+        Assert::assertSame(1, $this->countCompanyLeadRows($contact->getId(), $company->getId()));
+    }
+
+    public function testBatchAddContactsAlreadyAssigned(): void
+    {
+        $company = $this->createCompany('Batch Co D');
+        $contact = $this->createContact('batch-existing@example.com');
+        $this->companyModel->addLeadToCompany($company, $contact);
+
+        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+            'assignments' => [
+                ['contactId' => $contact->getId(), 'companyId' => $company->getId()],
+            ],
+        ]);
+
+        $response = $this->decodeResponse();
+        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        Assert::assertSame(Response::HTTP_OK, $response['results'][0]['status']);
+        Assert::assertSame(1, $response['summary']['succeeded']);
+        // idempotent — still exactly one row in DB
+        Assert::assertSame(1, $this->countCompanyLeadRows($contact->getId(), $company->getId()));
+    }
+
+    public function testBatchAddContactsNoPermissionPerItem(): void
+    {
+        $adminContact = $this->createContact('batch-admin-contact@example.com');
+        $company      = $this->createCompany('Batch Co E');
+
+        $salesUser = $this->em->getRepository(User::class)->findOneBy(['username' => self::SALES_USER]);
+        Assert::assertInstanceOf(User::class, $salesUser);
+        $this->setLeadPermissions($salesUser, ['editown']);
+
+        $this->client->setServerParameter('PHP_AUTH_USER', self::SALES_USER);
+        $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
+
+        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+            'assignments' => [
+                ['contactId' => $adminContact->getId(), 'companyId' => $company->getId()],
+            ],
+        ]);
+
+        $response = $this->decodeResponse();
+        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        Assert::assertSame(Response::HTTP_FORBIDDEN, $response['results'][0]['status']);
+        Assert::assertSame('Access denied', $response['results'][0]['message']);
+        Assert::assertFalse($this->isContactInCompany($adminContact->getId(), $company->getId()));
+    }
+
+    public function testBatchAddContactsGlobalForbiddenWithoutEditPermission(): void
+    {
+        $salesUser = $this->em->getRepository(User::class)->findOneBy(['username' => self::SALES_USER]);
+        Assert::assertInstanceOf(User::class, $salesUser);
+        $this->setLeadPermissions($salesUser, ['viewown', 'viewother']);
+
+        $this->client->setServerParameter('PHP_AUTH_USER', self::SALES_USER);
+        $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
+
+        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+            'assignments' => [
+                ['contactId' => 1, 'companyId' => 1],
+            ],
+        ]);
+
+        Assert::assertSame(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testBatchAddContactsExceedsBatchLimit(): void
+    {
+        $assignments = [];
+        for ($i = 0; $i < 201; ++$i) {
+            $assignments[] = ['contactId' => 1, 'companyId' => 1];
+        }
+
+        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+            'assignments' => $assignments,
+        ]);
+
+        Assert::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $this->client->getResponse()->getStatusCode());
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────
+
+    private function createCompany(string $name): Company
+    {
+        $company = new Company();
+        $company->setIsPublished(true);
+        $company->setName($name);
+        $this->companyModel->saveEntity($company);
+
+        return $company;
+    }
+
+    private function createContact(string $email): Lead
+    {
+        $contact = new Lead();
+        $contact->setEmail($email);
+        $this->leadModel->saveEntity($contact);
+
+        return $contact;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeResponse(): array
+    {
+        $content = $this->client->getResponse()->getContent();
+        Assert::assertNotFalse($content);
+
+        return json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    private function isContactInCompany(int $contactId, int $companyId): bool
+    {
+        return $this->countCompanyLeadRows($contactId, $companyId) > 0;
+    }
+
+    private function countCompanyLeadRows(int $contactId, int $companyId): int
+    {
+        $contact = $this->leadModel->getEntity($contactId);
+        $company = $this->companyModel->getEntity($companyId);
+
+        if (null === $contact || null === $company) {
+            return 0;
+        }
+
+        return null === $this->em->getRepository(CompanyLead::class)->findOneBy([
+            'lead'    => $contact,
+            'company' => $company,
+        ]) ? 0 : 1;
+    }
+
+    /**
+     * @param list<string> $permissions
+     */
+    private function setLeadPermissions(User $user, array $permissions): void
+    {
+        $role = $user->getRole();
+        Assert::assertNotNull($role);
+
+        $this->em->createQueryBuilder()
+            ->delete(Permission::class, 'p')
+            ->where('p.bundle = :bundle')
+            ->andWhere('p.role = :role_id')
+            ->setParameters(['bundle' => 'lead', 'role_id' => $role->getId()])
+            ->getQuery()
+            ->execute();
+
+        $role->setIsAdmin(false);
+        $roleModel = static::getContainer()->get('mautic.user.model.role');
+        \assert($roleModel instanceof RoleModel);
+        $roleModel->setRolePermissions($role, ['lead:leads' => $permissions]);
+        $this->em->persist($role);
+        $this->em->flush();
     }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
@@ -49,8 +49,8 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
 
         parent::setUp();
 
-        $this->companyModel = static::getContainer()->get('mautic.lead.model.company');
-        $this->leadModel    = static::getContainer()->get('mautic.lead.model.lead');
+        $this->companyModel = static::getContainer()->get(CompanyModel::class);
+        $this->leadModel    = static::getContainer()->get(LeadModel::class);
     }
 
     public function testBatchNewEndpoint(): void
@@ -168,7 +168,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $contact = $this->createLead('Batch', 'Success', 'batch-success@example.com');
         $this->em->flush();
 
-        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+        $this->requestBatchAddContacts([
             'assignments' => [
                 ['contactId' => $contact->getId(), 'companyId' => $company->getId()],
             ],
@@ -181,7 +181,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame(0, $response['summary']['failed']);
         Assert::assertSame(Response::HTTP_OK, $response['results'][0]['status']);
         Assert::assertSame('Contact added to company', $response['results'][0]['message']);
-        Assert::assertSame(1, $this->countCompanyLeadRows($contact->getId(), $company->getId()));
+        Assert::assertTrue($this->hasContactCompany($contact->getId(), $company->getId()));
     }
 
     public function testBatchAddContactsPartialFailure(): void
@@ -190,7 +190,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $contact = $this->createLead('Batch', 'Partial', 'batch-partial@example.com');
         $this->em->flush();
 
-        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+        $this->requestBatchAddContacts([
             'assignments' => [
                 ['contactId' => $contact->getId(), 'companyId' => $company->getId()],
                 ['contactId' => $contact->getId(), 'companyId' => 999999],
@@ -212,7 +212,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testBatchAddContactsEmptyBody(): void
     {
-        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', []);
+        $this->requestBatchAddContacts([]);
 
         Assert::assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
     }
@@ -223,7 +223,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $contact = $this->createLead('Batch', 'Dup', 'batch-dup@example.com');
         $this->em->flush();
 
-        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+        $this->requestBatchAddContacts([
             'assignments' => [
                 ['contactId' => $contact->getId(), 'companyId' => $company->getId()],
                 ['contactId' => $contact->getId(), 'companyId' => $company->getId()],
@@ -238,7 +238,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertCount(2, $response['results']);
         Assert::assertSame(Response::HTTP_OK, $response['results'][0]['status']);
         Assert::assertSame(Response::HTTP_OK, $response['results'][1]['status']);
-        Assert::assertSame(1, $this->countCompanyLeadRows($contact->getId(), $company->getId()));
+        Assert::assertTrue($this->hasContactCompany($contact->getId(), $company->getId()));
     }
 
     public function testBatchAddContactsAlreadyAssigned(): void
@@ -248,7 +248,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->companyModel->addLeadToCompany($company, $contact);
 
-        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+        $this->requestBatchAddContacts([
             'assignments' => [
                 ['contactId' => $contact->getId(), 'companyId' => $company->getId()],
             ],
@@ -258,7 +258,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
         Assert::assertSame(Response::HTTP_OK, $response['results'][0]['status']);
         Assert::assertSame(1, $response['summary']['succeeded']);
-        Assert::assertSame(1, $this->countCompanyLeadRows($contact->getId(), $company->getId()));
+        Assert::assertTrue($this->hasContactCompany($contact->getId(), $company->getId()));
     }
 
     public function testBatchAddContactsNoPermissionPerItem(): void
@@ -274,7 +274,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->setServerParameter('PHP_AUTH_USER', self::SALES_USER);
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
-        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+        $this->requestBatchAddContacts([
             'assignments' => [
                 ['contactId' => $adminContact->getId(), 'companyId' => $company->getId()],
             ],
@@ -284,7 +284,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
         Assert::assertSame(Response::HTTP_FORBIDDEN, $response['results'][0]['status']);
         Assert::assertSame('Access denied', $response['results'][0]['message']);
-        Assert::assertSame(0, $this->countCompanyLeadRows($adminContact->getId(), $company->getId()));
+        Assert::assertFalse($this->hasContactCompany($adminContact->getId(), $company->getId()));
     }
 
     public function testBatchAddContactsGlobalForbiddenWithoutEditPermission(): void
@@ -296,7 +296,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->setServerParameter('PHP_AUTH_USER', self::SALES_USER);
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
-        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+        $this->requestBatchAddContacts([
             'assignments' => [
                 ['contactId' => 1, 'companyId' => 1],
             ],
@@ -312,11 +312,26 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
             $assignments[] = ['contactId' => 1, 'companyId' => 1];
         }
 
-        $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
+        $this->requestBatchAddContacts([
             'assignments' => $assignments,
         ]);
 
         Assert::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function requestBatchAddContacts(array $payload): void
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/companies/batch/addcontacts',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode($payload, JSON_THROW_ON_ERROR)
+        );
     }
 
     /**
@@ -330,19 +345,16 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         return json_decode($content, true, 512, JSON_THROW_ON_ERROR);
     }
 
-    private function countCompanyLeadRows(int $contactId, int $companyId): int
+    private function hasContactCompany(int $contactId, int $companyId): bool
     {
         $contact = $this->leadModel->getEntity($contactId);
         $company = $this->companyModel->getEntity($companyId);
+        \assert(null !== $contact && null !== $company);
 
-        if (null === $contact || null === $company) {
-            return 0;
-        }
-
-        return null === $this->em->getRepository(CompanyLead::class)->findOneBy([
+        return null !== $this->em->getRepository(CompanyLead::class)->findOneBy([
             'lead'    => $contact,
             'company' => $company,
-        ]) ? 0 : 1;
+        ]);
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use Mautic\LeadBundle\Entity\Company;
+use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\Entity\CompanyLead;
-use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
@@ -20,6 +19,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
 {
+    use CreateTestEntitiesTrait;
+
     private const SALES_USER = 'sales';
 
     private CompanyModel $companyModel;
@@ -51,8 +52,6 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->companyModel = static::getContainer()->get('mautic.lead.model.company');
         $this->leadModel    = static::getContainer()->get('mautic.lead.model.lead');
     }
-
-    // ─── existing company API tests (from upstream 5.2) ─────────────────────
 
     public function testBatchNewEndpoint(): void
     {
@@ -163,12 +162,11 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertNotEquals($companyId, $response['company']['id']);
     }
 
-    // ─── batch addcontacts tests ─────────────────────────────────────────────
-
     public function testBatchAddContactsSuccess(): void
     {
-        $company = $this->createCompany('Batch Co A');
-        $contact = $this->createContact('batch-success@example.com');
+        $company = $this->createCompany('Batch Co A', 'batch-co-a@example.com');
+        $contact = $this->createLead('Batch', 'Success', 'batch-success@example.com');
+        $this->em->flush();
 
         $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
             'assignments' => [
@@ -183,13 +181,14 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame(0, $response['summary']['failed']);
         Assert::assertSame(Response::HTTP_OK, $response['results'][0]['status']);
         Assert::assertSame('Contact added to company', $response['results'][0]['message']);
-        Assert::assertTrue($this->isContactInCompany($contact->getId(), $company->getId()));
+        Assert::assertSame(1, $this->countCompanyLeadRows($contact->getId(), $company->getId()));
     }
 
     public function testBatchAddContactsPartialFailure(): void
     {
-        $company = $this->createCompany('Batch Co B');
-        $contact = $this->createContact('batch-partial@example.com');
+        $company = $this->createCompany('Batch Co B', 'batch-co-b@example.com');
+        $contact = $this->createLead('Batch', 'Partial', 'batch-partial@example.com');
+        $this->em->flush();
 
         $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
             'assignments' => [
@@ -220,8 +219,9 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testBatchAddContactsDuplicatePairs(): void
     {
-        $company = $this->createCompany('Batch Co C');
-        $contact = $this->createContact('batch-dup@example.com');
+        $company = $this->createCompany('Batch Co C', 'batch-co-c@example.com');
+        $contact = $this->createLead('Batch', 'Dup', 'batch-dup@example.com');
+        $this->em->flush();
 
         $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
             'assignments' => [
@@ -232,21 +232,20 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $response = $this->decodeResponse();
         Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
-        // total reflects original input count (including duplicates), succeeded+failed == total
         Assert::assertSame(2, $response['summary']['total']);
         Assert::assertSame(2, $response['summary']['succeeded']);
         Assert::assertSame(0, $response['summary']['failed']);
         Assert::assertCount(2, $response['results']);
         Assert::assertSame(Response::HTTP_OK, $response['results'][0]['status']);
         Assert::assertSame(Response::HTTP_OK, $response['results'][1]['status']);
-        // only one DB row despite two identical input pairs
         Assert::assertSame(1, $this->countCompanyLeadRows($contact->getId(), $company->getId()));
     }
 
     public function testBatchAddContactsAlreadyAssigned(): void
     {
-        $company = $this->createCompany('Batch Co D');
-        $contact = $this->createContact('batch-existing@example.com');
+        $company = $this->createCompany('Batch Co D', 'batch-co-d@example.com');
+        $contact = $this->createLead('Batch', 'Existing', 'batch-existing@example.com');
+        $this->em->flush();
         $this->companyModel->addLeadToCompany($company, $contact);
 
         $this->client->request(Request::METHOD_POST, '/api/companies/batch/addcontacts', [
@@ -259,14 +258,14 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
         Assert::assertSame(Response::HTTP_OK, $response['results'][0]['status']);
         Assert::assertSame(1, $response['summary']['succeeded']);
-        // idempotent — still exactly one row in DB
         Assert::assertSame(1, $this->countCompanyLeadRows($contact->getId(), $company->getId()));
     }
 
     public function testBatchAddContactsNoPermissionPerItem(): void
     {
-        $adminContact = $this->createContact('batch-admin-contact@example.com');
-        $company      = $this->createCompany('Batch Co E');
+        $adminContact = $this->createLead('Batch', 'Admin', 'batch-admin-contact@example.com');
+        $company      = $this->createCompany('Batch Co E', 'batch-co-e@example.com');
+        $this->em->flush();
 
         $salesUser = $this->em->getRepository(User::class)->findOneBy(['username' => self::SALES_USER]);
         Assert::assertInstanceOf(User::class, $salesUser);
@@ -285,7 +284,7 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
         Assert::assertSame(Response::HTTP_FORBIDDEN, $response['results'][0]['status']);
         Assert::assertSame('Access denied', $response['results'][0]['message']);
-        Assert::assertFalse($this->isContactInCompany($adminContact->getId(), $company->getId()));
+        Assert::assertSame(0, $this->countCompanyLeadRows($adminContact->getId(), $company->getId()));
     }
 
     public function testBatchAddContactsGlobalForbiddenWithoutEditPermission(): void
@@ -320,27 +319,6 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $this->client->getResponse()->getStatusCode());
     }
 
-    // ─── helpers ─────────────────────────────────────────────────────────────
-
-    private function createCompany(string $name): Company
-    {
-        $company = new Company();
-        $company->setIsPublished(true);
-        $company->setName($name);
-        $this->companyModel->saveEntity($company);
-
-        return $company;
-    }
-
-    private function createContact(string $email): Lead
-    {
-        $contact = new Lead();
-        $contact->setEmail($email);
-        $this->leadModel->saveEntity($contact);
-
-        return $contact;
-    }
-
     /**
      * @return array<string, mixed>
      */
@@ -350,11 +328,6 @@ class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertNotFalse($content);
 
         return json_decode($content, true, 512, JSON_THROW_ON_ERROR);
-    }
-
-    private function isContactInCompany(int $contactId, int $companyId): bool
-    {
-        return $this->countCompanyLeadRows($contactId, $companyId) > 0;
     }
 
     private function countCompanyLeadRows(int $contactId, int $companyId): int

--- a/app/bundles/LeadBundle/Tests/Model/BatchCompanyContactAssignmentModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/BatchCompanyContactAssignmentModelTest.php
@@ -7,7 +7,6 @@ namespace Mautic\LeadBundle\Tests\Model;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
-use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\BatchCompanyContactAssignmentModel;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
@@ -27,19 +26,13 @@ class BatchCompanyContactAssignmentModelTest extends TestCase
     /** @var CorePermissions&MockObject */
     private CorePermissions $security;
 
-    /** @var LeadRepository&MockObject */
-    private LeadRepository $leadRepository;
-
     private BatchCompanyContactAssignmentModel $model;
 
     protected function setUp(): void
     {
-        $this->companyModel   = $this->createMock(CompanyModel::class);
-        $this->leadModel      = $this->createMock(LeadModel::class);
-        $this->security       = $this->createMock(CorePermissions::class);
-        $this->leadRepository = $this->createMock(LeadRepository::class);
-
-        $this->leadModel->method('getRepository')->willReturn($this->leadRepository);
+        $this->companyModel = $this->createMock(CompanyModel::class);
+        $this->leadModel    = $this->createMock(LeadModel::class);
+        $this->security     = $this->createMock(CorePermissions::class);
 
         $this->model = new BatchCompanyContactAssignmentModel(
             $this->companyModel,
@@ -48,27 +41,10 @@ class BatchCompanyContactAssignmentModelTest extends TestCase
         );
     }
 
-    public function testDedupeAssignmentsKeepsFirstOccurrenceOrder(): void
-    {
-        $assignments = [
-            ['contactId' => 1, 'companyId' => 7],
-            ['contactId' => 5, 'companyId' => 10],
-            ['contactId' => 1, 'companyId' => 7],
-        ];
-
-        Assert::assertSame(
-            [
-                ['contactId' => 1, 'companyId' => 7],
-                ['contactId' => 5, 'companyId' => 10],
-            ],
-            BatchCompanyContactAssignmentModel::dedupeAssignments($assignments)
-        );
-    }
-
     public function testProcessReturns404ForMissingContact(): void
     {
-        $this->leadRepository->method('findBy')->willReturn([]);
-        $this->companyModel->method('getRepository')->willReturn($this->createMockCompanyRepository([]));
+        $this->leadModel->method('getEntities')->willReturn([]);
+        $this->companyModel->method('getEntities')->willReturn([]);
 
         $payload = $this->model->process([
             ['contactId' => 99, 'companyId' => 1],
@@ -85,8 +61,8 @@ class BatchCompanyContactAssignmentModelTest extends TestCase
     {
         $contact = $this->createContact(1, 10);
 
-        $this->leadRepository->method('findBy')->willReturn([$contact]);
-        $this->companyModel->method('getRepository')->willReturn($this->createMockCompanyRepository([]));
+        $this->leadModel->method('getEntities')->willReturn([$contact]);
+        $this->companyModel->method('getEntities')->willReturn([]);
 
         $payload = $this->model->process([
             ['contactId' => 1, 'companyId' => 999],
@@ -102,8 +78,8 @@ class BatchCompanyContactAssignmentModelTest extends TestCase
         $contact = $this->createContact(1, 10);
         $company = $this->createCompany(7);
 
-        $this->leadRepository->method('findBy')->willReturn([$contact]);
-        $this->companyModel->method('getRepository')->willReturn($this->createMockCompanyRepository([$company]));
+        $this->leadModel->method('getEntities')->willReturn([$contact]);
+        $this->companyModel->method('getEntities')->willReturn([$company]);
         $this->security->method('hasEntityAccess')->willReturn(false);
 
         // Expectation must be set before process() to correctly catch unexpected calls.
@@ -122,8 +98,8 @@ class BatchCompanyContactAssignmentModelTest extends TestCase
         $contact = $this->createContact(1, 10);
         $company = $this->createCompany(7);
 
-        $this->leadRepository->method('findBy')->willReturn([$contact]);
-        $this->companyModel->method('getRepository')->willReturn($this->createMockCompanyRepository([$company]));
+        $this->leadModel->method('getEntities')->willReturn([$contact]);
+        $this->companyModel->method('getEntities')->willReturn([$company]);
         $this->security->method('hasEntityAccess')->willReturn(true);
         $this->companyModel->expects($this->once())
             ->method('addLeadToCompany')
@@ -143,8 +119,8 @@ class BatchCompanyContactAssignmentModelTest extends TestCase
         $contact = $this->createContact(1, 10);
         $company = $this->createCompany(7);
 
-        $this->leadRepository->method('findBy')->willReturn([$contact]);
-        $this->companyModel->method('getRepository')->willReturn($this->createMockCompanyRepository([$company]));
+        $this->leadModel->method('getEntities')->willReturn([$contact]);
+        $this->companyModel->method('getEntities')->willReturn([$company]);
         $this->security->method('hasEntityAccess')->willReturn(true);
         $this->companyModel->expects($this->once())
             ->method('addLeadToCompany')
@@ -170,8 +146,8 @@ class BatchCompanyContactAssignmentModelTest extends TestCase
         $company7  = $this->createCompany(7);
         $company11 = $this->createCompany(11);
 
-        $this->leadRepository->method('findBy')->willReturn([$contact]);
-        $this->companyModel->method('getRepository')->willReturn($this->createMockCompanyRepository([$company7, $company11]));
+        $this->leadModel->method('getEntities')->willReturn([$contact]);
+        $this->companyModel->method('getEntities')->willReturn([$company7, $company11]);
         $this->security->method('hasEntityAccess')->willReturn(true);
         $this->companyModel->expects($this->once())
             ->method('addLeadToCompany')
@@ -211,18 +187,5 @@ class BatchCompanyContactAssignmentModelTest extends TestCase
         $company->method('getId')->willReturn($id);
 
         return $company;
-    }
-
-    /**
-     * @param Company[] $companies
-     *
-     * @return \Mautic\LeadBundle\Entity\CompanyRepository&MockObject
-     */
-    private function createMockCompanyRepository(array $companies): object
-    {
-        $repo = $this->createMock(\Mautic\LeadBundle\Entity\CompanyRepository::class);
-        $repo->method('findBy')->willReturn($companies);
-
-        return $repo;
     }
 }

--- a/app/bundles/LeadBundle/Tests/Model/BatchCompanyContactAssignmentModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/BatchCompanyContactAssignmentModelTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Model;
+
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Model\BatchCompanyContactAssignmentModel;
+use Mautic\LeadBundle\Model\CompanyModel;
+use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class BatchCompanyContactAssignmentModelTest extends TestCase
+{
+    /** @var CompanyModel&MockObject */
+    private CompanyModel $companyModel;
+
+    /** @var LeadModel&MockObject */
+    private LeadModel $leadModel;
+
+    /** @var CorePermissions&MockObject */
+    private CorePermissions $security;
+
+    /** @var LeadRepository&MockObject */
+    private LeadRepository $leadRepository;
+
+    private BatchCompanyContactAssignmentModel $model;
+
+    protected function setUp(): void
+    {
+        $this->companyModel   = $this->createMock(CompanyModel::class);
+        $this->leadModel      = $this->createMock(LeadModel::class);
+        $this->security       = $this->createMock(CorePermissions::class);
+        $this->leadRepository = $this->createMock(LeadRepository::class);
+
+        $this->leadModel->method('getRepository')->willReturn($this->leadRepository);
+
+        $this->model = new BatchCompanyContactAssignmentModel(
+            $this->companyModel,
+            $this->leadModel,
+            $this->security
+        );
+    }
+
+    public function testDedupeAssignmentsKeepsFirstOccurrenceOrder(): void
+    {
+        $assignments = [
+            ['contactId' => 1, 'companyId' => 7],
+            ['contactId' => 5, 'companyId' => 10],
+            ['contactId' => 1, 'companyId' => 7],
+        ];
+
+        Assert::assertSame(
+            [
+                ['contactId' => 1, 'companyId' => 7],
+                ['contactId' => 5, 'companyId' => 10],
+            ],
+            BatchCompanyContactAssignmentModel::dedupeAssignments($assignments)
+        );
+    }
+
+    public function testProcessReturns404ForMissingContact(): void
+    {
+        $this->leadRepository->method('findBy')->willReturn([]);
+        $this->companyModel->method('getRepository')->willReturn($this->createMockCompanyRepository([]));
+
+        $payload = $this->model->process([
+            ['contactId' => 99, 'companyId' => 1],
+        ]);
+
+        Assert::assertSame(1, $payload['summary']['total']);
+        Assert::assertSame(0, $payload['summary']['succeeded']);
+        Assert::assertSame(1, $payload['summary']['failed']);
+        Assert::assertSame(Response::HTTP_NOT_FOUND, $payload['results'][0]['status']);
+        Assert::assertSame('Contact not found', $payload['results'][0]['message']);
+    }
+
+    public function testProcessReturns404ForMissingCompany(): void
+    {
+        $contact = $this->createContact(1, 10);
+
+        $this->leadRepository->method('findBy')->willReturn([$contact]);
+        $this->companyModel->method('getRepository')->willReturn($this->createMockCompanyRepository([]));
+
+        $payload = $this->model->process([
+            ['contactId' => 1, 'companyId' => 999],
+        ]);
+
+        Assert::assertSame(Response::HTTP_NOT_FOUND, $payload['results'][0]['status']);
+        Assert::assertSame('Company not found', $payload['results'][0]['message']);
+        Assert::assertSame(1, $payload['summary']['failed']);
+    }
+
+    public function testProcessReturns403WhenContactEditDenied(): void
+    {
+        $contact = $this->createContact(1, 10);
+        $company = $this->createCompany(7);
+
+        $this->leadRepository->method('findBy')->willReturn([$contact]);
+        $this->companyModel->method('getRepository')->willReturn($this->createMockCompanyRepository([$company]));
+        $this->security->method('hasEntityAccess')->willReturn(false);
+
+        // Expectation must be set before process() to correctly catch unexpected calls.
+        $this->companyModel->expects($this->never())->method('addLeadToCompany');
+
+        $payload = $this->model->process([
+            ['contactId' => 1, 'companyId' => 7],
+        ]);
+
+        Assert::assertSame(Response::HTTP_FORBIDDEN, $payload['results'][0]['status']);
+        Assert::assertSame(1, $payload['summary']['failed']);
+    }
+
+    public function testProcessAssignsAndReturns200ForValidPair(): void
+    {
+        $contact = $this->createContact(1, 10);
+        $company = $this->createCompany(7);
+
+        $this->leadRepository->method('findBy')->willReturn([$contact]);
+        $this->companyModel->method('getRepository')->willReturn($this->createMockCompanyRepository([$company]));
+        $this->security->method('hasEntityAccess')->willReturn(true);
+        $this->companyModel->expects($this->once())
+            ->method('addLeadToCompany')
+            ->with([7], $contact);
+
+        $payload = $this->model->process([
+            ['contactId' => 1, 'companyId' => 7],
+        ]);
+
+        Assert::assertSame(Response::HTTP_OK, $payload['results'][0]['status']);
+        Assert::assertSame(1, $payload['summary']['total']);
+        Assert::assertSame(1, $payload['summary']['succeeded']);
+    }
+
+    public function testProcessDuplicatePairsReturn200TwiceButModelCalledOnce(): void
+    {
+        $contact = $this->createContact(1, 10);
+        $company = $this->createCompany(7);
+
+        $this->leadRepository->method('findBy')->willReturn([$contact]);
+        $this->companyModel->method('getRepository')->willReturn($this->createMockCompanyRepository([$company]));
+        $this->security->method('hasEntityAccess')->willReturn(true);
+        $this->companyModel->expects($this->once())
+            ->method('addLeadToCompany')
+            ->with([7], $contact);
+
+        $payload = $this->model->process([
+            ['contactId' => 1, 'companyId' => 7],
+            ['contactId' => 1, 'companyId' => 7],
+        ]);
+
+        // total reflects the original input count (including duplicates)
+        Assert::assertSame(2, $payload['summary']['total']);
+        Assert::assertCount(2, $payload['results']);
+        Assert::assertSame(Response::HTTP_OK, $payload['results'][0]['status']);
+        Assert::assertSame(Response::HTTP_OK, $payload['results'][1]['status']);
+        Assert::assertSame(2, $payload['summary']['succeeded']);
+        Assert::assertSame(0, $payload['summary']['failed']);
+    }
+
+    public function testProcessGroupsMultipleCompaniesPerContact(): void
+    {
+        $contact   = $this->createContact(5, 10);
+        $company7  = $this->createCompany(7);
+        $company11 = $this->createCompany(11);
+
+        $this->leadRepository->method('findBy')->willReturn([$contact]);
+        $this->companyModel->method('getRepository')->willReturn($this->createMockCompanyRepository([$company7, $company11]));
+        $this->security->method('hasEntityAccess')->willReturn(true);
+        $this->companyModel->expects($this->once())
+            ->method('addLeadToCompany')
+            ->with(
+                $this->callback(static function (array $companyIds): bool {
+                    sort($companyIds);
+
+                    return [7, 11] === $companyIds;
+                }),
+                $contact
+            );
+
+        $payload = $this->model->process([
+            ['contactId' => 5, 'companyId' => 7],
+            ['contactId' => 5, 'companyId' => 11],
+        ]);
+
+        Assert::assertSame(2, $payload['summary']['total']);
+        Assert::assertSame(2, $payload['summary']['succeeded']);
+    }
+
+    private function createContact(int $id, int $ownerId): Lead
+    {
+        $owner = $this->createMock(\Mautic\UserBundle\Entity\User::class);
+        $owner->method('getId')->willReturn($ownerId);
+
+        $contact = new Lead();
+        $contact->setId($id);
+        $contact->setOwner($owner);
+
+        return $contact;
+    }
+
+    private function createCompany(int $id): Company
+    {
+        $company = $this->createMock(Company::class);
+        $company->method('getId')->willReturn($id);
+
+        return $company;
+    }
+
+    /**
+     * @param Company[] $companies
+     *
+     * @return \Mautic\LeadBundle\Entity\CompanyRepository&MockObject
+     */
+    private function createMockCompanyRepository(array $companies): object
+    {
+        $repo = $this->createMock(\Mautic\LeadBundle\Entity\CompanyRepository::class);
+        $repo->method('findBy')->willReturn($companies);
+
+        return $repo;
+    }
+}


### PR DESCRIPTION
https://leuchtfeuer-com.atlassian.net/browse/MTC-10741

Implementation Decisions That Deviate From the Ticket Spec
1. HTTP 207 Multi-Status → HTTP 200
Spec: HTTP 207 Multi-Status — always returned when the batch was processed, even if some entries failed.

Implementation: Returns HTTP 200 for all processed batches (including partial failures), consistent with every other Mautic batch endpoint (/api/contacts/batch/new, /api/segments/{id}/contacts/add, etc.). HTTP 207 is unused in Mautic core and would require non-standard handling in API clients integrated with the platform.

2. No request-level database transaction
Spec: Wrap the entire loop in a single database transaction; roll back only on unexpected exceptions, not on per-item 404/403.

Implementation: No explicit transaction wraps the request. Each successful assignment group is committed immediately by addLeadToCompany() (which internally calls saveEntities → flush). This matches the behaviour of all other Mautic batch endpoints — partial success means partial persistence in the database. The AC "Transactional Integrity: n/a" was taken as supporting this decision.

Practical consequence: if the request contains 100 pairs and pair #90 throws an unexpected exception, pairs 1–89 are already committed. This is the accepted trade-off for partial-success batch APIs in Mautic.

3. Hard batch limit of 200 enforced, not just documented
Spec: No hard limit imposed at the API level, but documentation should recommend a maximum of 200 entries per request.

Implementation: The limit is enforced at the API level via validateBatchPayload(), consistent with all other Mautic batch endpoints. The limit is configurable via the api_batch_max_limit config parameter (default 200). Exceeding it returns HTTP 500 (Mautic standard for this check — semantically it should be 400, but that is a pre-existing Mautic behaviour, not introduced here). The recommended maximum is documented in this spec diff and in the devdocs entry.

4. "Company-edit permission" → lead:leads:editown / lead:leads:editother
Spec: HTTP 403 returned if the authenticated user has no company-edit permissions at all.

Implementation: Mautic has no separate company:edit permission. CompanyModel::getPermissionBase() returns lead:leads (this is a documented intentional BC decision in the codebase). The global 403 check is therefore: user has neither lead:leads:editown nor lead:leads:editother. Per-item 403 uses hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $contact->getPermissionUser()), identical to the existing single addContactAction.

5. summary.total counts original input, not deduplicated pairs
Spec: Does not specify this case explicitly, but the example implies total == succeeded + failed.

Implementation: summary.total = count($assignments) (original input, including duplicate entries). This guarantees total == succeeded + failed at all times. The number of unique pairs actually processed against the database is not exposed in the response.

Example for two identical pairs:

{ "total": 2, "succeeded": 2, "failed": 0 }

6. Logic extracted to a dedicated service class
Spec: Sketch places all logic inside batchAddContactsAction() in the controller, with a note to extend CompanyModel.

Implementation: Core processing logic lives in BatchCompanyContactAssignmentModel (autowired service). The controller method is a thin adapter: permission check → input validation → delegate → return view. This makes the business logic independently unit-testable without bootstrapping the full HTTP stack.

7. Bulk entity loading, not per-item getEntity()

Spec: Controller sketch calls $this->getModel('lead')->getEntity($contactId) and $this->getModel('lead.company')->getEntity($companyId) inside the loop.

Implementation: All unique contact IDs and company IDs are collected first, then loaded in two bulk queries via LeadModel::getEntities() and CompanyModel::getEntities() with ['ids' => $ids, 'iterable_mode' => true]. Per-item validation then works off in-memory maps. Valid pairs are grouped by contactId; company IDs per contact are sorted before a single addLeadToCompany([$companyId1, $companyId2, ...], $contact) call, so the model is invoked once per contact, not once per pair.

8. Routing registration location
Spec: Mentions app/bundles/ApiBundle/EventListener/... and app/config/routing/api.php as files to touch.

Implementation: Route is registered in app/bundles/LeadBundle/Config/config.php under the routes → api key, which is how all non-standard Company API routes (addContactAction, removeContactAction) are already registered. The ApiBundle event listener and routing/api.php are not modified; they are not the correct registration point for bundle-specific routes in Mautic 5.